### PR TITLE
Update HH Rust as official group

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Language Specific
 
 * **HH Ruby**: http://hh.gd/ruby
 
-* HH Rust: https://www.facebook.com/groups/hhrust/
+* **HH Rust**: https://www.facebook.com/groups/hhrust/
 
 * HH Gophers: https://www.facebook.com/groups/hhgophers/
 


### PR DESCRIPTION
Rust is now an official group. See group info for details as well as sidebar of main HH group for confirmation.