### PR TITLE
Remove "HH" from "Hedgehog Hackers"

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Events and Regions
 Humor
 ----
 - [HH Hacker Problems](https://www.facebook.com/groups/hhproblems/)
-- [HH Hedgehog Hackers](https://www.facebook.com/groups/hedgehoghackers/)
+- [Hedgehog Hackers](https://www.facebook.com/groups/hedgehoghackers/)
 - [HH Snackathon Snackers](https://www.facebook.com/groups/697736156983878/)
 - [HH Stackathon Stackers](https://www.facebook.com/groups/345926665565678/)
 - [Real Singles of HH](https://www.facebook.com/groups/realsingleshhct/)


### PR DESCRIPTION
For the record: This change has nothing to do with the recent events, the group has always been known as simply Hedgehog Hackers, without a HH prefix.